### PR TITLE
added method for closing meetings

### DIFF
--- a/src/bot/plugins/matching.py
+++ b/src/bot/plugins/matching.py
@@ -18,3 +18,14 @@ class Matching(Plugin):
             self.driver.reply_to(message, "Создание пар завершено")
         except Exception as error:
             self.driver.reply_to(message, str(error))
+
+    @listen_to("/close", re.IGNORECASE)
+    @inject
+    async def test_closing_meetings(
+        self, message: Message, matching_service: MatchingService = Provide[Container.matching_service]
+    ) -> None:
+        try:
+            await matching_service.run_closing_meetings()
+            self.driver.reply_to(message, "Встречи закрыты")
+        except Exception as error:
+            self.driver.reply_to(message, str(error))

--- a/src/bot/services/matching.py
+++ b/src/bot/services/matching.py
@@ -26,3 +26,7 @@ class MatchingService:
                 user.matches.append(match)
                 await self._user_repository.update(user.id, user)
         return matches
+
+    async def run_closing_meetings(self):
+        """Запускает закрытие встреч."""
+        return await self._match_repository.closing_meetings()

--- a/src/core/db/migrations/versions/cebca1c19787_test.py
+++ b/src/core/db/migrations/versions/cebca1c19787_test.py
@@ -1,0 +1,48 @@
+"""test
+
+Revision ID: cebca1c19787
+Revises: ae30bf2db609
+Create Date: 2023-10-26 22:56:39.340776
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "cebca1c19787"
+down_revision = "ae30bf2db609"
+branch_labels = None
+depends_on = None
+
+old_options = (
+    "ONGOING",
+    "SUCCESSFUL",
+    "UNSUCCESSFUL",
+)
+new_options = ("ONGOING", "CLOSED")
+
+old_type = sa.Enum(*old_options, name="matchstatusenum")
+new_type = sa.Enum(*new_options, name="matchstatusenum")
+tmp_type = sa.Enum(*new_options, name="_matchstatusenum")
+
+
+def upgrade():
+    tmp_type.create(op.get_bind(), checkfirst=False)
+    op.execute(
+        "ALTER TABLE usersmatch ALTER COLUMN status TYPE _matchstatusenum" " USING status::text::_matchstatusenum"
+    )
+    old_type.drop(op.get_bind(), checkfirst=False)
+    new_type.create(op.get_bind(), checkfirst=False)
+    op.execute("ALTER TABLE usersmatch ALTER COLUMN status TYPE matchstatusenum" " USING status::text::matchstatusenum")
+    tmp_type.drop(op.get_bind(), checkfirst=False)
+
+
+def downgrade():
+    tmp_type.create(op.get_bind(), checkfirst=False)
+    op.execute(
+        "ALTER TABLE usersmatch ALTER COLUMN status TYPE _matchstatusenum" " USING status::text::_matchstatusenum"
+    )
+    new_type.drop(op.get_bind(), checkfirst=False)
+    old_type.create(op.get_bind(), checkfirst=False)
+    op.execute("ALTER TABLE usersmatch ALTER COLUMN status TYPE matchstatusenum" " USING status::text::matchstatusenum")
+    tmp_type.drop(op.get_bind(), checkfirst=False)

--- a/src/core/db/models.py
+++ b/src/core/db/models.py
@@ -15,8 +15,7 @@ class StatusEnum(StrEnum):
 
 class MatchStatusEnum(StrEnum):
     ONGOING = "ONGOING"
-    SUCCESSFUL = "SUCCESSFUL"
-    UNSUCCESSFUL = "UNSUCCESSFUL"
+    CLOSED = "CLOSED"
 
 
 class Base(DeclarativeBase):
@@ -56,4 +55,4 @@ class UsersMatch(Base):
 
     matched_user_one: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     matched_user_two: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
-    status: Mapped[MatchStatusEnum] = mapped_column(default=MatchStatusEnum.UNSUCCESSFUL, nullable=False)
+    status: Mapped[MatchStatusEnum] = mapped_column(default=MatchStatusEnum.ONGOING, nullable=False)


### PR DESCRIPTION
# Description

Остались вопросы по миграциям. Думаю, должен быть более лучший вариант.  Пробовал методы alter_column и пакетную миграцию. В них при закрытии встреч появлялась ошибка, которая не позволяла изменить статус на CLOSED. Текущая миграция использует старый метод execute. В ней заметил особенность, что DBeaver отображает старые статусы. Закрытие встреч при этом с помощью нового метода closing_meetings проходит успешно.
![dbeaver](https://github.com/Studio-Yandex-Practicum/RandomCoffeeBot/assets/114247529/a4a03741-bee1-4383-b971-bebc56b47549)


## Type of change

Пожалуйста, удалите варианты, которые не относятся к ПР-у.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Для тестирования необходимо обновить миграции. Создать несколько пользователей со статусом `WAITING_MEETINGS`. Написать боту `/match` для создания встреч. Закрыть их с помощью `/close`.

# Checklist:

- [ ] Мой код соответствует code-style данного проекта
- [ ] Я провел самоанализ собственного кода
- [ ] Я внес соответствующие изменения в документацию
