### PR TITLE
Feature no pair message

### DIFF
--- a/src/bot/plugins/admin.py
+++ b/src/bot/plugins/admin.py
@@ -67,12 +67,16 @@ class BotAdmin(Plugin):
     @is_admin
     @inject
     async def test(
-        self, message: Message, matching_service: MatchingService = Provide[Container.matching_service]
+        self,
+        message: Message,
+        matching_service: MatchingService = Provide[Container.matching_service],
+        notify_service: NotifyService = Provide[Container.week_routine_service],
     ) -> None:
         """Тестирование создания пар"""
         try:
             reply_text = await matching_service.run_matching()
             self.driver.reply_to(message, reply_text)
+            await notify_service.send_no_pair_messages(plugin=self)
         except Exception as error:
             self.driver.reply_to(message, str(error))
 

--- a/src/bot/plugins/week_routine.py
+++ b/src/bot/plugins/week_routine.py
@@ -35,10 +35,11 @@ class WeekRoutine(Plugin):
             kwargs=dict(plugin=self, title="Еженедельный пятничный опрос"),
         )
         scheduler.add_job(
-            matching_service.run_matching,
+            self.run_matching_and_no_pair_messages,
             "cron",
             day_of_week=DAY_OF_WEEK_SUNDAY,
             hour=SUNDAY_TIME_SENDING_MESSAGE,
+            kwargs=dict(notify_service=notify_service, matching_service=matching_service),
         )
         scheduler.add_job(
             notify_service.meeting_notifications,
@@ -142,3 +143,11 @@ class WeekRoutine(Plugin):
     ) -> None:
         await notify_service.match_review_notifications(plugin=self)
         await matching_service.run_closing_meetings()
+
+    async def run_matching_and_no_pair_messages(
+        self,
+        notify_service: NotifyService,
+        matching_service: MatchingService,
+    ) -> None:
+        await matching_service.run_matching()
+        await notify_service.send_no_pair_messages(plugin=self)

--- a/src/bot/services/notify_service.py
+++ b/src/bot/services/notify_service.py
@@ -4,7 +4,7 @@ from mattermostautodriver.exceptions import InvalidOrMissingParameters
 from mmpy_bot import Plugin
 
 from src.bot.schemas import Actions, Attachment, Context, Integration
-from src.core.db.models import MatchStatusEnum, User
+from src.core.db.models import MatchStatusEnum, StatusEnum, User
 from src.core.db.repository.match_review import MatchReviewRepository
 from src.core.db.repository.user import UserRepository
 from src.core.db.repository.usersmatch import UsersMatchRepository
@@ -117,3 +117,16 @@ class NotifyService:
                     )
                 except InvalidOrMissingParameters as error:
                     logger.error(str(error))
+
+    async def send_no_pair_messages(self, plugin: Plugin) -> None:
+        for user in await self._user_repository.get_by_status(status=StatusEnum.WAITING_MEETING):
+            await self._user_repository.set_not_involved_status(user_id=user.id)
+            try:
+                plugin.driver.direct_message(
+                    receiver_id=user.user_id,
+                    message="К сожалению на этой неделе тебе не нашлось пары,"
+                    " но мы уверены, что тебе обязательно повезёт на "
+                    "следующей неделе!",
+                )
+            except InvalidOrMissingParameters as error:
+                logger.error(str(error))

--- a/src/core/db/repository/user.py
+++ b/src/core/db/repository/user.py
@@ -75,3 +75,9 @@ class UserRepository(AbstractRepository[User]):
         if current_user is not None:
             current_user.status = StatusEnum.WAITING_MEETING
             await self.update(current_user.id, current_user)
+
+    async def set_not_involved_status(self, user_id: int) -> None:
+        """Устанавливает статус not_involved для юзера без пары"""
+        current_user = await self.get(instance_id=user_id)
+        current_user.status = StatusEnum.NOT_INVOLVED
+        await self.update(user_id, current_user)


### PR DESCRIPTION
# Description

Добавил отправку сообщения пользователям, которым не нашлось пары. 

Если пользователь остался без пары, он находится в статусе WAITING_MEETING. После образования мэтчей всем пользователям с таким статусом рассылается сообщение и их статус меняется на NOT_INVOLVED

